### PR TITLE
S1 n2rr1 f/2737 new channels for failure and success GitHub actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: 18.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
 
-      - name: Send Slack notification
+      - name: Send Slack notification for Success
         if: steps.publish.outputs.type != 'none' && success()
         uses: 8398a7/action-slack@v3
         with:
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SUCCESS_WEBHOOK_URL }}
 
-      - name: Send Slack notification
+      - name: Send Slack notification for Failure
         if: steps.publish.outputs.type != 'none' && (failure() || cancelled())
         uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,3 +54,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: steps.publish.outputs.type != 'none' && always()
+
+      - name: Send Slack notification
+        if: steps.publish.outputs.type != 'none' && success()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,workflow,took
+          text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SUCCESS_WEBHOOK_URL }}
+
+      - name: Send Slack notification
+        if: steps.publish.outputs.type != 'none' && (failure() || cancelled())
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,workflow,took
+          text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAILED_WEBHOOK_URL }}
+  

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,17 +45,6 @@ jobs:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Send Slack notification
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo
-          text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: steps.publish.outputs.type != 'none' && always()
-
-      - name: Send Slack notification
         if: steps.publish.outputs.type != 'none' && success()
         uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: 18.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notificationapi/core",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notificationapi/core",
-      "version": "0.0.10",
+      "version": "0.0.12",
       "devDependencies": {
         "@types/jest": "^29.5.3",
         "@types/node": "^20.14.10",


### PR DESCRIPTION
Update Slack notification and GitHub actions versions.
- Send Slack notifications based on the GitHub build being successful or if it failed.
- Upgrade actions to latest versions to address versions that are being deprecated.