### PR TITLE
Update Slack notification

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Send Slack notification for Success
-        if: steps.publish.outputs.type != 'none' && success()
+        if: success()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
@@ -56,12 +56,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SUCCESS_WEBHOOK_URL }}
 
       - name: Send Slack notification for Failure
-        if: steps.publish.outputs.type != 'none' && (failure() || cancelled())
+        if: failure() || cancelled()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: repo,message,commit,workflow,took
-          text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAILED_WEBHOOK_URL }}


### PR DESCRIPTION
Update Slack notification to send to one channel if build is successful, or to another channel if build fails.