### PR TITLE
feat(slack): add hasMoreChannels and hasMoreUsers to getChannels response

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -135,6 +135,8 @@ type NotificationAPIClientSDK = {
       channels: SlackChannel[];
       users: SlackUser[];
       me: SlackUser;
+      hasMoreChannels?: boolean;
+      hasMoreUsers?: boolean;
     }>;
     setChannel: (channelId: string) => Promise<void>;
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notificationapi/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@notificationapi/core",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/jest": "^29.5.3",
         "@types/node": "^20.14.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notificationapi/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -370,6 +370,28 @@ describe('NotificationAPIClientSDK', () => {
       })
     );
   });
+  test('slack.getChannels should return hasMoreChannels and hasMoreUsers from API', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({
+        channels: [{ id: 'C123', name: 'general' }],
+        users: [{ id: 'U123', name: 'alice' }],
+        me: { id: 'U123', name: 'alice' },
+        hasMoreChannels: true,
+        hasMoreUsers: false
+      })
+    };
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+    const sdk = NotificationAPIClientSDK.init({
+      userId: 'testUser',
+      clientId: 'testClient'
+    });
+
+    const result = await sdk.slack.getChannels();
+
+    expect(result.hasMoreChannels).toBe(true);
+    expect(result.hasMoreUsers).toBe(false);
+  });
 });
 
 describe('api function', () => {


### PR DESCRIPTION
## Description:
Adds hasMoreChannels and hasMoreUsers to the getChannels response type so the SDK matches the updated Slack channels API.

Minor patch update since this introduces new optional fields to the getChannels response and is still backward compatible.

## Related Trello Ticket:
https://trello.com/c/Y2wHekHu/4470-getsift-user-issue-not-seeing-slack-channels

## Testing
- [x] Manual testing performed
- [x] Added unit testing for new optional fields